### PR TITLE
Put ref .7 back into path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,6 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
       - name: Test App
-        uses: STEM-C/auto/mocks
+        uses: STEM-C/auto/mocks@v0.7
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
It seems like it requires the workflow format to include the ref