### PR TITLE
Fix/sort block category

### DIFF
--- a/server/api/block/services/block.js
+++ b/server/api/block/services/block.js
@@ -1,13 +1,11 @@
 'use strict'
 
 const sortCategory = (toolbox) =>{
-    console.log('Original: ', toolbox)
     const order = ['Logic', 'Control', 'Math', 'Text', 'Variables', 'Functions', 'IO', 'Time', 'Audio', 'Motors', 'Comms'];
 
     const sorted = toolbox.sort(function(a,b) {
         return order.indexOf(a[0]) - order.indexOf(b[0]);
     })
-    console.log('After: ', sorted)
     return sorted;
 }
 

--- a/server/api/block/services/block.js
+++ b/server/api/block/services/block.js
@@ -1,5 +1,16 @@
 'use strict'
 
+const sortCategory = (toolbox) =>{
+    console.log('Original: ', toolbox)
+    const order = ['Logic', 'Control', 'Math', 'Text', 'Variables', 'Functions', 'IO', 'Time', 'Audio', 'Motors', 'Comms'];
+
+    const sorted = toolbox.sort(function(a,b) {
+        return order.indexOf(a[0]) - order.indexOf(b[0]);
+    })
+    console.log('After: ', sorted)
+    return sorted;
+}
+
 // get all the blocks for a day
 module.exports.findByDay = async (id) => {
 
@@ -13,7 +24,7 @@ module.exports.findByDay = async (id) => {
 // create a blockly friendly toolbox from blocks
 module.exports.blocksToToolbox = (blocks) => {
 
-    let toolbox = {}
+    let toolbox = {};
     blocks.forEach(block => {
 
         // validate the block fields
@@ -31,6 +42,7 @@ module.exports.blocksToToolbox = (blocks) => {
             toolbox[blocks_category.name] = [sanitizedBlock]
         }
     })
-
-    return Object.entries(toolbox)
+    const arr = Object.entries(toolbox)
+    
+    return sortCategory(arr);
 }


### PR DESCRIPTION
Blockly category was ordered by the time modified. I sorted them in the following order: 
'Logic', 'Control', 'Math', 'Text', 'Variables', 'Functions', 'IO', 'Time', 'Audio', 'Motors', 'Comms'