### PR TITLE
fix day level report filter bug

### DIFF
--- a/client/src/views/Researcher/DayLevelReport.js
+++ b/client/src/views/Researcher/DayLevelReport.js
@@ -150,7 +150,7 @@ const DayLevelReport = () => {
     {
       title: 'Lesson',
       dataIndex: ['learning_standard', 'name'],
-      key: 'unit',
+      key: 'learning_standard',
       width: '3%',
       align: 'left',
       filters: tbLessonFilter,


### PR DESCRIPTION
the key for the _unit_ column and _lesson_ column have the same value, causing filtering on either one of the two column to affect one another